### PR TITLE
BUG: fix drone concurrent builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,6 +3,7 @@ pipeline:
     image: docker/compose:1.23.2
     commands:
       - cp .env-template .env
+      - sed -i "s/COMPOSE_PROJECT_NAME=.*/COMPOSE_PROJECT_NAME=enigma_${DRONE_BUILD_NUMBER}/" .env
       - docker network prune -f || true
       - docker-compose down --rmi all -v || true
       - docker-compose build --no-cache


### PR DESCRIPTION
Concurrent builds on the Drone CI fail because the docker networks collide in having the same name when trying to launch the network with the following error:
```
2 matches found based on name: network enigma_net is ambiguous
```
that's even despite forcibly removing any stale network from previous builds at the very beginning [here](https://github.com/enigmampc/discovery-integration-tests/blob/6d627138d3fa39854faf0b70c23081a639d6081e/.drone.yml#L6). 

The implemented solution is to name each network uniquely using the `DRONE_BUILD_NUMBER` that Drone makes available as an environment variable to each build.