### PR TITLE
BLD: restructuring client start

### DIFF
--- a/config/docker-compose.cli-hw.yml
+++ b/config/docker-compose.cli-hw.yml
@@ -16,8 +16,10 @@ services:
     environment:
       - SGX_MODE=${SGX_MODE}
     volumes:
-      - "built_contracts:/root/enigma-contract/build/contracts"
+      - "${BUILD_CONTRACTS_PATH}:/root/enigma-contract/build/contracts"
       - "shared:/root/.enigma"
+    ports:
+      - "9545:9545"
 
   p2p:
     image: enigmampc/enigma_p2p
@@ -33,7 +35,9 @@ services:
     environment:
       - NETWORK=${COMPOSE_PROJECT_NAME}
     volumes:
-        - "built_contracts:/root/enigma-p2p/test/ethereum/scripts/build/contracts"
+        - "${BUILD_CONTRACTS_PATH}:/root/enigma-p2p/test/ethereum/scripts/build/contracts"
+    ports:
+      - "3346:3346"
 
   client:
     image: enigmampc/enigma_contract
@@ -42,11 +46,15 @@ services:
     networks:
       - net
     hostname: client
+    entrypoint:
+      - /bin/bash
+      - -c
+      - ./login_workers.bash; bash
     environment:
       - NETWORK=${COMPOSE_PROJECT_NAME}
       - NODES
     volumes:
-      - "built_contracts:/root/enigma-contract/build/contracts"
+      - "${BUILD_CONTRACTS_PATH}:/root/enigma-contract/build/contracts"
 
   core:
     image: enigmampc/enigma_core_hw
@@ -74,5 +82,4 @@ networks:
     net:
 
 volumes:
-  built_contracts:
   shared:

--- a/config/docker-compose.cli-sw.yml
+++ b/config/docker-compose.cli-sw.yml
@@ -16,8 +16,10 @@ services:
     environment:
       - SGX_MODE=${SGX_MODE}
     volumes:
-      - "built_contracts:/root/enigma-contract/build/contracts"
+      - "${BUILD_CONTRACTS_PATH}:/root/enigma-contract/build/contracts"
       - "shared:/root/.enigma"
+    ports:
+      - "9545:9545"
 
   p2p:
     image: enigmampc/enigma_p2p
@@ -33,7 +35,9 @@ services:
     environment:
       - NETWORK=${COMPOSE_PROJECT_NAME}
     volumes:
-        - "built_contracts:/root/enigma-p2p/test/ethereum/scripts/build/contracts"
+        - "${BUILD_CONTRACTS_PATH}:/root/enigma-p2p/test/ethereum/scripts/build/contracts"
+    ports:
+      - "3346:3346"
 
   client:
     image: enigmampc/enigma_contract
@@ -42,11 +46,15 @@ services:
     networks:
       - net
     hostname: client
+    entrypoint:
+      - /bin/bash
+      - -c
+      - ./login_workers.bash; bash
     environment:
       - NETWORK=${COMPOSE_PROJECT_NAME}
       - NODES
     volumes:
-      - "built_contracts:/root/enigma-contract/build/contracts"
+      - "${BUILD_CONTRACTS_PATH}:/root/enigma-contract/build/contracts"
 
   core:
     image: enigmampc/enigma_core_sw
@@ -70,5 +78,4 @@ networks:
     net:
 
 volumes:
-  built_contracts:
   shared:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
     environment:
       - NETWORK=${COMPOSE_PROJECT_NAME}
       - NODES
+      - SGX_MODE
     volumes:
       - "built_contracts:/root/enigma-contract/build/contracts"
 

--- a/enigma-contract/Dockerfile
+++ b/enigma-contract/Dockerfile
@@ -16,10 +16,13 @@ RUN npm install
 RUN cd enigma-js && yarn install
 
 WORKDIR /root
-COPY start_test.bash .
-COPY launch_ganache.bash .
 COPY simpleHTTP1.bash .
 COPY simpleHTTP2.bash .
+COPY init.bash .
+COPY start_test.bash .
+COPY login_workers.bash .
+COPY launch_ganache.bash .
+
 RUN mkdir -p /root/.enigma
 
 ENTRYPOINT ["/usr/bin/env"]

--- a/enigma-contract/init.bash
+++ b/enigma-contract/init.bash
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Environment variable NETWORK is set through docker-compose.yml
+
+cd /root/enigma-contract/enigma-js
+
+echo "Waiting for ${NETWORK}_p2p_1..."
+until curl -s -m 1 ${NETWORK}_p2p_1:3346; do sleep 3; done
+
+echo "Waiting for ${NETWORK}_p2p_1 to register..."
+sleep 8
+
+proxy=$(getent hosts ${NETWORK}_p2p_1 | awk '{ print $1 }')
+contract=$(getent hosts contract | awk '{ print $1 }')
+
+for filename in test/integrationTests/template.*; do 
+	sed -e "s_http://[localhost|.0-9]*:3346_http://$proxy:3346_" $filename > $(echo $filename | sed "s/template\.\(.*\).js/\1.spec.js/")
+    sed -i "s_http://[localhost|.0-9]*:9545_http://$contract:9545_" $(echo $filename | sed "s/template\.\(.*\).js/\1.spec.js/")
+done

--- a/enigma-contract/login_workers.bash
+++ b/enigma-contract/login_workers.bash
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+./init.bash
+cd enigma-contract/enigma-js/test/integrationTests/ && yarn test:integration 01_init.spec.js

--- a/enigma-contract/start_test.bash
+++ b/enigma-contract/start_test.bash
@@ -1,25 +1,4 @@
 #!/bin/bash
 
-# Environment variable NETWORK is set through docker-compose.yml
-
-cd /root/enigma-contract/enigma-js
-
-echo "Waiting for ${NETWORK}_p2p_1..."
-until curl -s -m 1 ${NETWORK}_p2p_1:3346; do sleep 3; done
-
-echo "Waiting for ${NETWORK}_p2p_1 to register..."
-sleep 5
-
-proxy=$(getent hosts ${NETWORK}_p2p_1 | awk '{ print $1 }')
-contract=$(getent hosts contract | awk '{ print $1 }')
-contractaddress=$(curl -s http://contract:8081)
-tokenaddress=$(curl -s http://contract:8082)
-
-for filename in test/integrationTests/template.*; do 
-	sed -e "s_http://[localhost|.0-9]*:3346_http://$proxy:3346_" $filename > $(echo $filename | sed "s/template\.\(.*\).js/\1.spec.js/")
-    sed -i "s_http://[localhost|.0-9]*:9545_http://$contract:9545_" $(echo $filename | sed "s/template\.\(.*\).js/\1.spec.js/")
-	sed -i "s/EnigmaContract.networks\['4447'\].address/'$contractaddress'/" $(echo $filename | sed "s/template\.\(.*\).js/\1.spec.js/")
-	sed -i "s/EnigmaTokenContract.networks\['4447'\].address/'$tokenaddress'/" $(echo $filename | sed "s/template\.\(.*\).js/\1.spec.js/")
-done
-
-test/integrationTests/runTests.bash
+./init.bash
+cd enigma-contract/enigma-js && test/integrationTests/runTests.bash


### PR DESCRIPTION
Restructured the way client starts, separating scripts for:
- discovery-cli will use `login_workers.bash` (only executes `01_init.spec.js`
- integration tests will continue to use `start_test.bash`