### PR TITLE
Change P2P node version to 10

### DIFF
--- a/enigma-p2p/Dockerfile
+++ b/enigma-p2p/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11 as runtime
+FROM node:10 as runtime
 
 LABEL maintainer='info@enigma.co'
 


### PR DESCRIPTION
Enigma-p2p is currently based on Node 10.14