### PR TITLE
Ganache timeout

### DIFF
--- a/enigma-contract/launch_ganache.bash
+++ b/enigma-contract/launch_ganache.bash
@@ -2,7 +2,7 @@
 rm -f /root/.enigma/principal-sign-addr.txt ./enigma-contract/enigmacontract.txt ./enigmacontract/enigmatokencontract.txt
 until [ -f /root/.enigma/principal-sign-addr.txt ];do sleep 1; done;
 
-ganache-cli -d -p 9545 -i 4447 -h 0.0.0.0 &
+ganache-cli -d -p 9545 -i 4447 -h 0.0.0.0 --keepAliveTimeout 30000 &
 sleep 5
 cd enigma-contract
 truffle compile


### PR DESCRIPTION
Increased Ganache server timeout from the default 5000 milliseconds to 30000