### PR TITLE
MAINT: downgrade to Node v10

### DIFF
--- a/enigma-contract/Dockerfile
+++ b/enigma-contract/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11 as runtime
+FROM node:10 as runtime
 
 LABEL maintainer='info@enigma.co'
 
@@ -12,7 +12,7 @@ RUN yarn global add ganache-cli truffle
 
 WORKDIR /root/enigma-contract
 
-RUN npm install
+RUN yarn install
 RUN cd enigma-js && yarn install
 
 WORKDIR /root

--- a/enigma-p2p/Dockerfile
+++ b/enigma-p2p/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11 as runtime
+FROM node:10 as runtime
 
 LABEL maintainer='info@enigma.co'
 


### PR DESCRIPTION
Downgrades the `contract` and `p2p` images from Node v11 (which is [no longer active nor maintained](https://nodejs.org/en/about/releases/)) to Node v10. Tried upgrading to v12, but the `keccak` dependency does not build with v12 (see cryptocoinjs/keccak#10), so waiting for that to be resolved before upgrading to v12.

@mdemri: this PR also addresses the `yarn install` that you pointed out recently so that we use the lock file that we have in the repo. Thank you.