### PR TITLE
BUG: fix network name in truffle.js

### DIFF
--- a/enigma-contract/launch_ganache.bash
+++ b/enigma-contract/launch_ganache.bash
@@ -6,7 +6,7 @@ ganache-cli -d -p 9545 -i 4447 -h 0.0.0.0 --keepAliveTimeout 30000 &
 sleep 5
 cd enigma-contract
 truffle compile
-truffle migrate --reset network development
+truffle migrate --reset --network develop
 cp build/contracts/Enigma.json build/contracts/EnigmaMock.json
 ~/simpleHTTP1.bash &
 ~/simpleHTTP2.bash &


### PR DESCRIPTION
Makes the complementary fix to enigmampc/enigma-contract#144. Until both PRs are committed, the CIs will mutually break, so this PR needs to be merged with a broken CI, merge the contract one, and then re-run this one to pass.