### PR TITLE
MAINT: updated Dockerfile, not uncoditional build

### DIFF
--- a/enigma-core/Dockerfile
+++ b/enigma-core/Dockerfile
@@ -16,7 +16,7 @@ ARG SGX_MODE
 RUN . /opt/sgxsdk/environment && . /root/.cargo/env && SGX_MODE=$SGX_MODE RUSTFLAGS=-Awarnings RUST_BACKTRACE=1 make DEBUG=1 || \
     echo "\n\n**** This is a known error. Ignore for now. Will succeed upon retry ***\n" && \
     rm -rf /root/.cargo/git/checkouts/rust-sgx-sdk-fc8771c5c45bde9a/212d9f4/xargo && \
-    SGX_MODE=$SGX_MODE RUSTFLAGS=-Awarnings RUST_BACKTRACE=1 make DEBUG=1 || true
+    SGX_MODE=$SGX_MODE RUSTFLAGS=-Awarnings RUST_BACKTRACE=1 make DEBUG=1
 
 WORKDIR /root
 COPY start_core.bash .

--- a/enigma-core/Dockerfile.km
+++ b/enigma-core/Dockerfile.km
@@ -15,7 +15,7 @@ ARG SGX_MODE
 RUN . /opt/sgxsdk/environment && . /root/.cargo/env && SGX_MODE=$SGX_MODE RUSTFLAGS=-Awarnings RUST_BACKTRACE=1 make DEBUG=1 || \
     echo "\n\n**** This is a known error. Ignore for now. Will succeed upon retry ***\n" && \
     rm -rf /root/.cargo/git/checkouts/rust-sgx-sdk-fc8771c5c45bde9a/212d9f4/xargo && \
-    SGX_MODE=$SGX_MODE RUSTFLAGS=-Awarnings RUST_BACKTRACE=1 make DEBUG=1 || true
+    SGX_MODE=$SGX_MODE RUSTFLAGS=-Awarnings RUST_BACKTRACE=1 make DEBUG=1
 
 WORKDIR /root
 COPY start_km.bash .


### PR DESCRIPTION
Removing a legacy configuration that was put in place when `core` builds used to fail frequently, and made the build appear successful even when no binary was built. Removing it now because we want to see the build fail early, otherwise integration tests may run forever and makes identifying the cause harder.

(Cc: @AvishaiW)