### PR TITLE
BUG: fix bash unary operator expected

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - ./start_worker.bash; bash
     environment:
       - NETWORK=${COMPOSE_PROJECT_NAME}
+      - NODES
     volumes:
         - "built_contracts:/root/enigma-p2p/test/ethereum/scripts/build/contracts"
 


### PR DESCRIPTION
- Edits in `enigma-p2p/start_worker.bash` resolve a bug that was observed recently with a hackathon (EthBoston) participant using a different flavor or *nix (Cc: @ainsleys FYI)

- This PR also includes a small improvement on how a worker scans for other workers in the network (related to the environment variable NODES)