### PR TITLE
TST: move from 1 to 3 nodes in integrationTest

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,7 @@ steps:
   - name: test
     image: docker/compose:1.23.2
     commands:
-      - NODES=3 docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client
+      - export NODES=3 && docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client
     volumes:
       - name: dockersock
         path: /var/run/docker.sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,7 @@ steps:
   - name: test
     image: docker/compose:1.23.2
     commands:
-      - docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml up --exit-code-from client
+      - NODES=3 docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client
     volumes:
       - name: dockersock
         path: /var/run/docker.sock

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ before_install:
   - cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=$BUILD -t enigmampc/enigma_p2p:$TAG --no-cache . && cd ..
 
 script:
-  - docker-compose -f docker-compose.yml -f docker-compose.test.yml up --exit-code-from client
+  - NODES=3 docker-compose -f docker-compose.yml -f docker-compose.test.yml up  --scale core=$NODES --scale p2p=$NODES --exit-code-from client

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ before_install:
   - cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=$BUILD -t enigmampc/enigma_p2p:$TAG --no-cache . && cd ..
 
 script:
-  - NODES=3 docker-compose -f docker-compose.yml -f docker-compose.test.yml up  --scale core=$NODES --scale p2p=$NODES --exit-code-from client
+  - export NODES=3 && docker-compose -f docker-compose.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client

--- a/enigma-contract/init.bash
+++ b/enigma-contract/init.bash
@@ -2,13 +2,18 @@
 
 # Environment variable NETWORK is set through docker-compose.yml
 
+# Check if $NODES is set
+if [ -z ${NODES+x} ]; then
+	NODES=1
+fi
+
 cd /root/enigma-contract/enigma-js
 
 echo "Waiting for ${NETWORK}_p2p_1..."
 until curl -s -m 1 ${NETWORK}_p2p_1:3346; do sleep 3; done
 
 echo "Waiting for ${NETWORK}_p2p_1 to register..."
-sleep 8
+sleep $((8*$NODES))
 
 proxy=$(getent hosts ${NETWORK}_p2p_1 | awk '{ print $1 }')
 contract=$(getent hosts contract | awk '{ print $1 }')


### PR DESCRIPTION
Increasing from `NODES=1` to `NODES=3` to run the integration tests for increased robustness of said tests.

Analogous to:
- enigmampc/enigma-contract#151
- enigmampc/enigma-core#226
- enigmampc/enigma-p2p#233