### PR TITLE
MAINT: fix to check unset variable in bash

### DIFF
--- a/enigma-contract/init.bash
+++ b/enigma-contract/init.bash
@@ -17,12 +17,12 @@ sleep $((8*$NODES))
 
 # if we initialized the enigma_proxy to a fixed IP address then take it from there,
 # otherwise, take it from getent.
-if [ -z ${ENIGMA_PROXY_IP} ]; then
+if [ -z ${ENIGMA_PROXY_IP+x} ]; then
   ENIGMA_PROXY_IP=$(getent hosts ${NETWORK}_p2p_1 | awk '{ print $1 }')
 fi
 
 # same as to the ip address of the contract
-if [ -z ${ENIGMA_CONTRACT_IP} ]; then
+if [ -z ${ENIGMA_CONTRACT_IP+x} ]; then
   ENIGMA_CONTRACT_IP=$(getent hosts contract | awk '{ print $1 }')
 fi
 


### PR DESCRIPTION
Improves on the edits introduced in e15729185d2e3d4408cc8d316efe8f041944de8e, because of what's explained [here](https://stackoverflow.com/questions/3601515/how-to-check-if-a-variable-is-set-in-bash)

Cc: @AvishaiW 