### PR TITLE
MAINT: do not build core/km images, just pull

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ before_install:
   - sed -i "s/-vv/-v/" enigma-core/start_core.bash      
   - if [[ ${TRAVIS_BRANCH} == "master" ]]; then export TAG=latest BUILD=master; else export TAG=develop BUILD=develop; fi
   - if [[ $TAG == "develop" ]]; then sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=develop/" .env; fi
-  - cd enigma-core && docker build --build-arg GIT_BRANCH_CORE=$BUILD --build-arg SGX_MODE=SW -t enigmampc/enigma_core_sw:$TAG --no-cache . && cd ..
-  - cd enigma-core && docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=$BUILD --build-arg SGX_MODE=SW -t enigmampc/enigma_km_sw:$TAG --no-cache . && cd ..
+  - docker pull enigmampc/enigma_core_sw:$TAG
+  - docker pull enigmampc/enigma_km_sw:$TAG
   - cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=$BUILD -t enigmampc/enigma_contract:$TAG --no-cache . && cd ..
   - cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=$BUILD -t enigmampc/enigma_p2p:$TAG --no-cache . && cd ..
 


### PR DESCRIPTION
We're hitting the 50min timeout limit for builds for Travis because building the 4 docker images takes a long time, so I'm choosing to just pull `core` and `km`, which both take the most time, and involve the least amount of configuration from this repo. It's a reasonable tradeoff.