### PR TITLE
added chain_id field to km configuration

### DIFF
--- a/enigma-core/principal_test_config.json
+++ b/enigma-core/principal_test_config.json
@@ -6,6 +6,7 @@
     "test_net": true,
     "with_private_key": false,
     "private_key": "",
+    "chain_id": "4447",
     "url": "http://localhost:9545",
     "epoch_size": 10,
     "polling_interval": 1,


### PR DESCRIPTION
This PR replaces #46
The reason for this replacement is that we want the CI system to pull the code from enigmampc/enigma-core#252 which has the same branch name.